### PR TITLE
feat: Use `onchange` instead of `oninput` for slider

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -7,8 +7,7 @@ function main() {
 
     let slider = document.getElementById("slider");
     window.spotify.setVolume(slider.value)
-    slider.oninput = function () { window.spotify.setVolume(slider.value) }
-
+    slider.onchange = function () { window.spotify.setVolume(slider.value) }
 
     for (const song of window.songs) {
         document.getElementById(song.feeling).onclick = function () { window.spotify.playSong(song.uri, song.offset_ms) }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,19 +1,28 @@
 function main() {
-    window.spotify.login()
-    for (const song of window.songs) {
-        document.getElementById("playlist").innerHTML +=
-            "<div style='background-color: " + songToColour(song) + "' class='button' id='" + song.feeling + "'> <img src='play.svg'>&emsp;" + song.feeling + "</div>";
-    }
+  window.spotify.login();
+  for (const song of window.songs) {
+    document.getElementById("playlist").innerHTML +=
+      "<div style='background-color: " + songToColour(song) +
+      "' class='button' id='" + song.feeling + "'> <img src='play.svg'>&emsp;" +
+      song.feeling + "</div>";
+  }
 
-    let slider = document.getElementById("slider");
-    window.spotify.setVolume(slider.value)
-    slider.onchange = function () { window.spotify.setVolume(slider.value) }
+  let slider = document.getElementById("slider");
+  window.spotify.setVolume(slider.value);
+  slider.onchange = function () {
+    window.spotify.setVolume(slider.value);
+  };
 
-    for (const song of window.songs) {
-        document.getElementById(song.feeling).onclick = function () { window.spotify.playSong(song.uri, song.offset_ms) }
-        document.getElementById(song.feeling).onpress = function () { window.spotify.playSong(song.uri, song.offset_ms) }
-    }
-    document.getElementById("togglePlay").onclick = window.spotify.pause
-    document.getElementById("togglePlay").onpress = window.spotify.pause
+  for (const song of window.songs) {
+    document.getElementById(song.feeling).onclick = function () {
+      window.spotify.playSong(song.uri, song.offset_ms);
+    };
+    document.getElementById(song.feeling).onpress = function () {
+      window.spotify.playSong(song.uri, song.offset_ms);
+    };
+  }
+
+  document.getElementById("togglePlay").onclick = window.spotify.pause;
+  document.getElementById("togglePlay").onpress = window.spotify.pause;
 }
-main()
+main();


### PR DESCRIPTION
This was simpler than I initially thought - the only code change is replacing `oninput` with `onchange`. I also added formatting to make `main.js` prettier.

Closes #11 